### PR TITLE
feature: make search forms collapsable

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,14 +100,15 @@
           <article class="border rounded p-3 control-container">
 
             <!-- header.control-header -->
-            <header class="control-header">
+            <header class="control-header" data-toggle="collapse" href="#nameForm" role="button"
+            aria-expanded="false" aria-controls="nameForm">
               <h3 class="control-title">Nome</h3>
               <small id="nameHelp" class="form-text text-muted control-description">Traz drinks com nome igual ou
                 similar</small>
             </header><!-- /header.control-header -->
 
             <!-- form#nameForm.control-form -->
-            <form id="nameForm" action="" method="get" class="mt-3 control-form">
+            <form id="nameForm" action="" method="get" class="mt-3 control-form collapse">
               <div class="form-group">
                 <label for="name" class="text-dark">Insira o nome</label>
                 <input type="text" class="form-control" id="name" aria-describedby="nameHelp" placeholder="Caipirinha"
@@ -128,13 +129,14 @@
           <article class="border rounded p-3 control-container">
 
             <!-- header.control-header -->
-            <header class="control-header">
+            <header class="control-header" data-toggle="collapse" href="#categoryForm" role="button"
+            aria-expanded="false" aria-controls="categoryForm">
               <h3 class="control-title">Categoria</h3>
               <small id="categoryHelp" class="form-text text-muted control-description">Traz drinks da categoria</small>
             </header><!-- /header.control-header -->
 
             <!-- form#categoryForm.control-form -->
-            <form id="categoryForm" action="" method="get" class="mt-3 control-form">
+            <form id="categoryForm" action="" method="get" class="mt-3 control-form collapse">
               <div class="form-group">
                 <label for="category" class="text-dark">Selecione a categoria</label>
                 <select name="category" id="category" class="form-control" aria-describedby="categoryHelp" required>
@@ -158,14 +160,15 @@
           <article class="border rounded p-3 control-container">
 
             <!-- header.control-header -->
-            <header class="control-header">
+            <header class="control-header" data-toggle="collapse" href="#randomForm" role="button"
+            aria-expanded="false" aria-controls="randomForm">
               <h3 class="control-title">Randômico</h3>
               <small id="randomHelp" class="form-text text-muted control-description">Traz um drink
                 aleatoriamente</small>
             </header><!-- /header.control-header -->
 
             <!-- form#randomForm.control-form -->
-            <form id="randomForm" action="" method="get" class="mt-3 control-form">
+            <form id="randomForm" action="" method="get" class="mt-3 control-form collapse">
               <button id="randomFormBtn" type="button"
                 class="btn btn-warning border border-rounded border-dark w-100">Buscar</button>
             </form><!-- /form.#randomFormcontrol-form -->
@@ -181,14 +184,15 @@
           <article class="border rounded p-3 control-container">
 
             <!-- header.control-header -->
-            <header class="control-header">
+            <header class="control-header" data-toggle="collapse" href="#firstLetterForm" role="button"
+            aria-expanded="false" aria-controls="firstLetterForm">
               <h3 class="control-title">Primeira Letra</h3>
               <small id="firstLetterHelp" class="form-text text-muted control-description">Traz drinks que começam com a
                 letra</small>
             </header><!-- /header.control-header -->
 
             <!-- form#firstLetterForm.control-form -->
-            <form id="firstLetterForm" action="" method="get" class="mt-3 control-form">
+            <form id="firstLetterForm" action="" method="get" class="mt-3 control-form collapse">
               <div class="form-group">
                 <label for="firstLetter" class="text-dark">Insira a primeira letra</label>
                 <input type="text" class="form-control" id="firstLetter" aria-describedby="firstLetterHelp"
@@ -209,13 +213,14 @@
           <article class="border rounded p-3 control-container">
 
             <!-- header.control-header -->
-            <header class="control-header">
+            <header class="control-header" data-toggle="collapse" href="#glassForm" role="button"
+            aria-expanded="false" aria-controls="glassForm">
               <h3 class="control-title">Tipos de Copo</h3>
               <small id="glassHelp" class="form-text text-muted control-description">Traz drinks para o copo</small>
             </header><!-- /header.control-header -->
 
             <!-- form#glassForm.control-form -->
-            <form id="glassForm" action="" method="get" class="mt-3 control-form">
+            <form id="glassForm" action="" method="get" class="mt-3 control-form collapse">
               <div class="form-group">
                 <label for="glass" class="text-dark">Selecione o copo</label>
                 <select name="glass" id="glass" class="form-control" aria-describedby="glassHelp" required>
@@ -239,14 +244,15 @@
           <article class="border rounded p-3 control-container">
 
             <!-- header.control-header -->
-            <header class="control-header">
+            <header class="control-header" data-toggle="collapse" href="#alcoholicForm" role="button"
+            aria-expanded="false" aria-controls="alcoholicForm">
               <h3 class="control-title">Alcoólicos ou não?</h3>
               <small id="alcoholicHelp" class="form-text text-muted control-description">Traz drinks com ou sem
                 álcool</small>
             </header><!-- /header.control-header -->
 
             <!-- form#alcoholicForm.control-form -->
-            <form id="alcoholicForm" action="" method="get" class="mt-3 control-form">
+            <form id="alcoholicForm" action="" method="get" class="mt-3 control-form collapse">
               <div class="form-group">
                 <label for="alcoholic" class="text-dark">Selecione a opção</label>
                 <select name="alcoholic" id="alcoholic" class="form-control" aria-describedby="alcoholicHelp" required>


### PR DESCRIPTION
# **Collapsable Search Forms** 

## **Goal**
To create interaction with the visitor by showing/hiding the search forms.

### **Problem**
Not really a problem, just add this Bootstrap feature.

##### **Dependencies**
Is it necessary to install have Bootstrap 4.5.2+ installed or its CDN.

### **Solution**
To apply Bootstrap classes to make those elements collapsable.

#### **QA**
Click each of the search forms and check if they do really collapse/uncollapse.